### PR TITLE
ptrace: always use memcpy() for matching as GCC optimizes

### DIFF
--- a/ptrace.c
+++ b/ptrace.c
@@ -526,12 +526,10 @@ bool searchregions(globals_t * vars, scan_match_type_t match_type, const userval
             address = r->start + offset;
 
 #if HAVE_PROCMEM
-#ifdef __arm__
-            /* Don't dereference as this causes an alignment issue on ARM */
+            /* Don't dereference as this causes an alignment issue e.g. on ARM.
+               GCC replaces memcpy() with dereferencing where possible. */
             memcpy(&data_value.int64_value, &data[offset], sizeof(int64_t));
-#else
-            data_value.int64_value    = *((int64_t *)(&data[offset]));
-#endif
+
             /* Mark which values this can't be */
             if (EXPECT((nread - offset < sizeof(int64_t)), false))
             {


### PR DESCRIPTION
Currently there is alignment awareness implemented only for ARM
as introduced by commit 2bd4ab72e8ff
"ptrace: ARM: copy data for matching instead of dereferencing".
But other CPU architectures are likely affected as well.

So always use memcpy(). GCC replaces it with dereferencing where
possible. Hence the assembly code remains exactly the same on
x86_64 and C code becomes much simpler.

Reported-by: Hraban Luyat \<hraban@0brg.net\>